### PR TITLE
Improve forum UI with header and cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,1 +1,5 @@
 @import "tailwindcss";
+
+body {
+  @apply bg-gray-100 text-gray-900;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
+import Header from '@/components/Header';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -24,7 +25,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="pt-br">
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>{children}</body>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} bg-gray-100 text-gray-900 min-h-screen flex flex-col`}
+      >
+        <Header />
+        <main className="flex-1">{children}</main>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,30 @@
+import PostCard from '@/components/PostCard';
+
+const posts = [
+  {
+    id: 1,
+    title: 'Bem-vindo ao Systempunk Forum',
+    excerpt:
+      'Este é o primeiro post do fórum. Sinta-se à vontade para começar uma discussão e compartilhar suas ideias.',
+    author: 'Admin',
+    date: '21/05/2024',
+  },
+  {
+    id: 2,
+    title: 'Compartilhe seus projetos',
+    excerpt:
+      'Mostre para a comunidade o que você tem desenvolvido e receba feedback de outros membros.',
+    author: 'Jane Doe',
+    date: '22/05/2024',
+  },
+];
+
 export default function Home() {
-  return <div></div>;
+  return (
+    <div className="container mx-auto space-y-6 px-4 py-8">
+      {posts.map((post) => (
+        <PostCard key={post.id} {...post} />
+      ))}
+    </div>
+  );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+import Button from '@/containers/atoms/button';
+
+export default function Header() {
+  return (
+    <header className="bg-white shadow">
+      <div className="container mx-auto flex items-center justify-between px-4 py-4">
+        <Link href="/" className="text-xl font-bold">
+          Systempunk Forum
+        </Link>
+        <Link href="#">
+          <Button level="primary" size="medium">
+            Nova Postagem
+          </Button>
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -1,0 +1,23 @@
+import Button from '@/containers/atoms/button';
+
+export type PostCardProps = {
+  title: string;
+  excerpt: string;
+  author: string;
+  date: string;
+};
+
+export default function PostCard({ title, excerpt, author, date }: PostCardProps) {
+  return (
+    <div className="rounded-lg bg-white p-6 shadow">
+      <h2 className="mb-2 text-2xl font-semibold">{title}</h2>
+      <p className="mb-4 text-sm text-gray-500">
+        {author} • {date}
+      </p>
+      <p className="mb-4">{excerpt}</p>
+      <Button level="primary" variant="solid">
+        Ler mais
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create Header and PostCard components
- add forum posts sample on home page
- style layout with modern Tailwind classes

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: network/timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_683f710831b883338a825e83b4d21cea