### PR TITLE
Add dynamic project page

### DIFF
--- a/app/projects/jogo/[id]/page.tsx
+++ b/app/projects/jogo/[id]/page.tsx
@@ -1,0 +1,170 @@
+import fs from 'fs/promises';
+import path from 'path';
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+
+interface Hero {
+  image: string;
+  title: string;
+  subtitle: string;
+}
+
+interface FastDescription {
+  description: string;
+  video: string;
+}
+
+interface NewsCard {
+  tags: string[];
+  title: string;
+  subtitle: string;
+  image: string;
+  year: number;
+  readingTime: string;
+}
+
+interface LoreSection {
+  title: string;
+  description: string;
+  image: string;
+}
+
+interface Footer {
+  company: string;
+  rating: string;
+  platforms: string[];
+  copyright: string;
+}
+
+interface GameData {
+  hero: Hero;
+  platforms: string[];
+  fastDescription: FastDescription;
+  lastNews: NewsCard[];
+  lore: LoreSection[];
+  media: string[];
+  footer: Footer;
+  customCss?: string;
+}
+
+async function getGameData(id: string): Promise<GameData> {
+  const filePath = path.join(process.cwd(), 'public', 'projects', 'jogo', `${id}.json`);
+  try {
+    const json = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(json) as GameData;
+  } catch (e) {
+    throw new Error('not-found');
+  }
+}
+
+export default async function GamePage({ params }: { params: { id: string } }) {
+  let data: GameData;
+  try {
+    data = await getGameData(params.id);
+  } catch {
+    notFound();
+  }
+
+  return (
+    <div>
+      {data.customCss && <link rel="stylesheet" href={data.customCss} />}
+
+      <section className="text-center py-8" id="hero">
+        <Image src={data.hero.image} alt={data.hero.title} width={800} height={400} className="mx-auto" />
+        <h1 className="text-3xl font-bold animate-fade-in mt-4">{data.hero.title}</h1>
+        <p className="text-lg text-muted-foreground">{data.hero.subtitle}</p>
+      </section>
+
+      <section className="py-8" id="platforms">
+        <h2 className="text-2xl font-semibold mb-2">Plataformas</h2>
+        <ul className="flex flex-wrap gap-4">
+          {data.platforms.map((p) => (
+            <li key={p} className="flex items-center gap-2 capitalize">
+              <PlatformIcon name={p} />
+              <span>{p}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="py-8 flex flex-col md:flex-row gap-4" id="fast-description">
+        <div className="flex-1">
+          <iframe
+            src={data.fastDescription.video}
+            className="w-full aspect-video"
+            allow="autoplay; encrypted-media"
+            title="Trailer"
+          />
+        </div>
+        <p className="flex-1 self-center text-lg">{data.fastDescription.description}</p>
+      </section>
+
+      <section className="py-8" id="news">
+        <h2 className="text-2xl font-semibold mb-4">Últimas notícias</h2>
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {data.lastNews.map((n, idx) => (
+            <article key={idx} className="border rounded-md overflow-hidden">
+              <div className="relative">
+                <Image src={n.image} alt={n.title} width={400} height={200} />
+                <div className="absolute top-0 left-0 bg-black bg-opacity-60 text-white text-xs p-1">
+                  {n.year} • {n.readingTime}
+                </div>
+              </div>
+              <div className="p-2">
+                <div className="mb-1 text-xs text-muted-foreground flex gap-1">
+                  {n.tags.map((t) => (
+                    <span key={t} className="bg-muted px-1 rounded-sm">
+                      {t}
+                    </span>
+                  ))}
+                </div>
+                <h3 className="font-bold">{n.title}</h3>
+                <p className="text-sm text-muted-foreground">{n.subtitle}</p>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="py-8" id="lore">
+        {data.lore.map((l, idx) => (
+          <div key={idx} className={`flex flex-col md:flex-row gap-4 mb-6 ${idx % 2 ? 'md:flex-row-reverse' : ''}`}>
+            <Image src={l.image} alt={l.title} width={400} height={200} className="flex-1" />
+            <div className="flex-1">
+              <h3 className="text-xl font-semibold mb-2">{l.title}</h3>
+              <p>{l.description}</p>
+            </div>
+          </div>
+        ))}
+      </section>
+
+      <section className="py-8" id="media">
+        <h2 className="text-2xl font-semibold mb-4">Galeria</h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+          {data.media.map((img, idx) => (
+            <Image key={idx} src={img} alt={`media-${idx}`} width={300} height={200} className="rounded" />
+          ))}
+        </div>
+      </section>
+
+      <footer className="py-8 text-center text-sm" id="footer">
+        <p>{data.footer.company}</p>
+        <p>{data.footer.platforms.join(', ')}</p>
+        <p>{data.footer.rating}</p>
+        <p>{data.footer.copyright}</p>
+      </footer>
+    </div>
+  );
+}
+
+function PlatformIcon({ name }: { name: string }) {
+  const icons: Record<string, string> = {
+    steam: '/steam.svg',
+    playstation: '/playstation.svg',
+    xbox: '/xbox.svg',
+    epic: '/epic.svg',
+    'itch.io': '/itchio.svg',
+  };
+  const src = icons[name.toLowerCase()] || '/file.svg';
+  return <Image src={src} alt={name} width={24} height={24} />;
+}

--- a/public/epic.svg
+++ b/public/epic.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M7 7h10v4H7zM7 13h10v4H7z" fill="#fff"/></svg>

--- a/public/itchio.svg
+++ b/public/itchio.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><rect x="2" y="6" width="20" height="12" rx="2"/><path d="M6 10h12v4H6z" fill="#fff"/></svg>

--- a/public/playstation.svg
+++ b/public/playstation.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M3 18l9-3v-9l9-3v3l-6 2v9l-12 4z"/></svg>

--- a/public/projects/jogo/MON.json
+++ b/public/projects/jogo/MON.json
@@ -1,0 +1,42 @@
+{
+  "hero": {
+    "image": "/logo.png",
+    "title": "Monocrom",
+    "subtitle": "Aventura em 2D"
+  },
+  "platforms": ["Steam", "Epic", "PlayStation", "Xbox"],
+  "fastDescription": {
+    "description": "Um jogo de plataforma 2D ambientado no universo Systempunk.",
+    "video": "https://www.youtube.com/embed/dQw4w9WgXcQ"
+  },
+  "lastNews": [
+    {
+      "tags": ["lançamento"],
+      "title": "Demo Disponível",
+      "subtitle": "Experimente agora mesmo",
+      "image": "/next.svg",
+      "year": 2024,
+      "readingTime": "2 min"
+    }
+  ],
+  "lore": [
+    {
+      "title": "Universo",
+      "description": "Descubra mundos monocromáticos cheios de mistério.",
+      "image": "/vercel.svg"
+    },
+    {
+      "title": "Personagens",
+      "description": "Heróis e vilões com histórias únicas.",
+      "image": "/file.svg"
+    }
+  ],
+  "media": ["/logo.png", "/systempunkBrand.png"],
+  "footer": {
+    "company": "Systempunk Studios",
+    "rating": "L",
+    "platforms": ["Steam", "Xbox", "PlayStation"],
+    "copyright": "© 2024"
+  },
+  "customCss": "/projects/jogo/mon-style.css"
+}

--- a/public/projects/jogo/mon-style.css
+++ b/public/projects/jogo/mon-style.css
@@ -1,0 +1,4 @@
+#hero {
+  background-color: #000;
+  color: #0f0;
+}

--- a/public/steam.svg
+++ b/public/steam.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M7 13l5 4 5-10" stroke="#fff" stroke-width="2" fill="none"/></svg>

--- a/public/xbox.svg
+++ b/public/xbox.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M7 7l10 10M17 7L7 17" stroke="#fff" stroke-width="2"/></svg>


### PR DESCRIPTION
## Summary
- create dynamic route `projects/jogo/[id]` that reads data from a JSON file
- add placeholder data and custom css for project `MON`
- include simple platform icons

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2e4dd8f48333acd260c6a226588c